### PR TITLE
Updated URL, date parsing and description parsing.

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -1,7 +1,7 @@
 require 'scraperwiki'
 require 'mechanize'
 
-url = 'https://www.surfcoast.vic.gov.au/My_Property/Building_Planning/Planning/Applications_On_Public_Exhibition'
+url = 'https://www.surfcoast.vic.gov.au/Property/Planning/View-applications-or-make-a-submission/Applications-on-public-exhibition'
 
 agent = Mechanize.new
 agent.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search(':span').at('.display-date').inner_text)
+    on_notice_to = Date.parse(r.search(:span).at('.display-date').inner_text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,7 +22,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    matches = r.search(:td)[3].inner_text.strip.split(/\u00a0/)
+    matches = r.search(:td)[3].inner_text.strip.gsub(/\u00a0/, ' ').split(' ')
     on_notice_from = ''
     on_notice_to = Date.parse(matches[1])
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search(:span).at('.display-date')[0].inner_text)
+    on_notice_to = Date.parse(r.search("//span[@class='.display-date']".text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -24,7 +24,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
 
     matches = r.search(:td)[3].inner_text.strip.gsub(/\u00a0/, ' ').split(' ')
     on_notice_from = ''
-    on_notice_to = Date.parse(matches[1])
+    on_notice_to = Date.parse(matches[2] + ' ' + matches[3] + ' ' + matches[4])
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,6 +22,9 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
+    puts r.search(:td)[2].inner_text
+    puts r.search(:td)[3].inner_text
+
     matches = r.search(:td)[3].inner_text.split('&nbsp;')
     on_notice_from = ''
     on_notice_to = Date.parse(matches[2])

--- a/scraper.rb
+++ b/scraper.rb
@@ -25,7 +25,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     puts r.search(:td)[2].text
     puts r.search(:td)[3].text
 
-    matches = r.search(:td)[3].text.split('&nbsp;')
+    matches = r.search(:td)[3].inner_text.split('\u00a0')
     on_notice_from = ''
     on_notice_to = Date.parse(matches[2])
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,8 +23,6 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     matches = r.search(:td)[3].inner_text.split(/\u00a0/)
-    puts matches
-    
     on_notice_from = ''
     on_notice_to = Date.parse(matches[2])
 
@@ -33,9 +31,9 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       address: detail_page.at(:h1).inner_text.strip + ", VIC",
       on_notice_from: on_notice_from,
       on_notice_to: on_notice_to,
-      description: detail_page.search('div.general_content').inner_text.split(/Proposal:(.*?)Permit No:/m)[1].gsub(/\u00a0/,'').strip,
+      description: detail_page.search('div.main-container').inner_text.split(/Proposal:(.*?)Permit No:/m)[1].gsub(/\u00a0/,'').strip,
       info_url: detail_page_url,
-      comment_url: "info@surfcoast.vic.gov.au",
+      comment_url: "planningapps@surfcoast.vic.gov.au",
       date_scraped: Date.today
     }
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search("//span[@class='.display-date']".text)
+    on_notice_to = Date.parse(r.search("//span[@class='.display-date']").text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,7 +22,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    matches = r.search(:td)[3].inner_text.split(/\u00a0/)
+    matches = r.search(:td)[3].inner_text.strip.split(/\u00a0/)
     on_notice_from = ''
     on_notice_to = Date.parse(matches[1])
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -24,7 +24,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
 
     matches = r.search(:td)[3].inner_text.split(/\u00a0/)
     on_notice_from = ''
-    on_notice_to = Date.parse(matches[2])
+    on_notice_to = Date.parse(matches[1])
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,14 +22,11 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    puts r.search(:td)[2].text
-    puts r.search(:td)[3].text
-
-    matches = r.search(:td)[3].inner_text.split(' ')
+    matches = r.search(:td)[3].inner_text.split(/\u00a0/)
     puts matches
     
     on_notice_from = ''
-    on_notice_to = Date.parse('#{matches[3]} #{matches[4]} #{matches[5]}')
+    on_notice_to = Date.parse(matches[2])
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,10 +22,10 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    puts r.search("//span[@class='.display-date']").text
-    puts r.search("//span[@class='.display-date']").inner_text
+    puts r.search("//span[@class='display-date']").text
+    puts r.search("//span[@class='display-date']").inner_text
     on_notice_from = ''
-    on_notice_to = Date.strptime(r.search("//span[@class='.display-date']").text, '%-d %b %Y')
+    on_notice_to = Date.strptime(r.search("//span[@class='display-date']").text, '%-d %b %Y')
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,10 +22,9 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    puts r.search("//span[@class='display-date']").text
-    puts r.search("//span[@class='display-date']").inner_text
+    matches = r.search(:td)[3].inner_text.split('&nbsp;')
     on_notice_from = ''
-    on_notice_to = Date.strptime(r.search("//span[@class='display-date']").text, '%-d %b %Y')
+    on_notice_to = Date.parse(matches[2])
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search(:span.display-date)[0].inner_text)
+    on_notice_to = Date.parse(r.search(':span.display-date')[0].inner_text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search(':span.display-date')[0].inner_text)
+    on_notice_to = Date.parse(r.search(':span').at('.display-date').inner_text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search("//span[@class='.display-date']").text)
+    on_notice_to = Date.strptime(r.search("//span[@class='.display-date']").text, '%-d %b %Y')
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -25,9 +25,11 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     puts r.search(:td)[2].text
     puts r.search(:td)[3].text
 
-    matches = r.search(:td)[3].inner_text.split('\u00a0')
+    matches = r.search(:td)[3].inner_text.split(' ')
+    puts matches
+    
     on_notice_from = ''
-    on_notice_to = Date.parse(matches[2])
+    on_notice_to = Date.parse('#{matches[3]} #{matches[4]} #{matches[5]}')
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,9 +22,8 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    matches = r.search(:td)[3].inner_text.split(' to ')
-    on_notice_from = Date.parse(matches[0])
-    on_notice_to = Date.parse(matches[1])
+    on_notice_from = ''
+    on_notice_to = Date.parse(r.search(:span.display-date)[0].inner_text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,6 +22,8 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
+    puts r.search("//span[@class='.display-date']").text
+    puts r.search("//span[@class='.display-date']").inner_text
     on_notice_from = ''
     on_notice_to = Date.strptime(r.search("//span[@class='.display-date']").text, '%-d %b %Y')
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -23,7 +23,7 @@ page.at(:table).search(:tr).each_with_index do |r,i|
     end
 
     on_notice_from = ''
-    on_notice_to = Date.parse(r.search(:span).at('.display-date').inner_text)
+    on_notice_to = Date.parse(r.search(:span).at('.display-date')[0].inner_text)
 
     record = {
       council_reference: council_reference,

--- a/scraper.rb
+++ b/scraper.rb
@@ -22,10 +22,10 @@ page.at(:table).search(:tr).each_with_index do |r,i|
       next
     end
 
-    puts r.search(:td)[2].inner_text
-    puts r.search(:td)[3].inner_text
+    puts r.search(:td)[2].text
+    puts r.search(:td)[3].text
 
-    matches = r.search(:td)[3].inner_text.split('&nbsp;')
+    matches = r.search(:td)[3].text.split('&nbsp;')
     on_notice_from = ''
     on_notice_to = Date.parse(matches[2])
 


### PR DESCRIPTION
Updated the URL to https://www.surfcoast.vic.gov.au/Property/Planning/View-applications-or-make-a-submission/Applications-on-public-exhibition.  The information on the web site no longer includes the "on notice from" date (but does still have the "on notice to" date) so updated the scraper to reflect this.  And also changed the scraper to obtain the description (again, due to a change on the web page: the div class name had changed).  See https://morph.io/planningalerts-scrapers/surf_coast.